### PR TITLE
Add doc for S3 region config option

### DIFF
--- a/docs/catalyst/admin/config.mdx
+++ b/docs/catalyst/admin/config.mdx
@@ -22,6 +22,7 @@ Complete list of configuration options for the Catalyst server:
 | `--arango-db-password`  /<br/> `ARANGO_DB_PASSWORD`  | string *(required)*                        | The password of the ArangoDB server                                              |
 | `--s3-host`             /<br/> `S3_HOST`             | string *(default: "http://minio:9000")*    | The host of the S3 server                                                        |
 | `--s3-user`             /<br/> `S3_USER`             | string *(default: "minio")*                | The user of the S3 server                                                        |
+| `--s3-region`           /<br/> `S3_REGION`           | string *(default: "us-east-1")*            | S3 Bucket region                                                                 |
 | `--s3-password`         /<br/> `S3_PASSWORD`         | string                                     | The password of the S3 server                                                    |
 
 ## OIDC Config


### PR DESCRIPTION
With catalyst version 0.11.0 we can offer an option to configure the required S3 Region.
This update notes that in the config documentation.

Note that currently version 0.11.0 is not working because of an dependency issue:
https://github.com/SecurityBrewery/catalyst/issues/1043